### PR TITLE
Bugfix. 'for' no longer shadows the 'foreach' keyword

### DIFF
--- a/src/Jade/Compiler.php
+++ b/src/Jade/Compiler.php
@@ -29,7 +29,7 @@ class Compiler
 
     protected $selfClosing  = array('meta', 'img', 'link', 'input', 'source', 'area', 'base', 'col', 'br', 'hr');
     protected $phpKeywords  = array('true','false','null','switch','case','default','endswitch','if','elseif','else','endif','while','endwhile','do','for','endfor','foreach','endforeach','as','unless');
-    protected $phpOpenBlock = array('switch','if','elseif','else','while','do','for','foreach','unless');
+    protected $phpOpenBlock = array('switch','if','elseif','else','while','do','foreach','for','unless');
     protected $phpCloseBlock= array('endswitch','endif','endwhile','endfor','endforeach');
 
     public function __construct($prettyprint=false, array $filters = array())


### PR DESCRIPTION
This is a bugfix for enabling the PHP `foreach` keyword which was shadowed by `for` and was compiled to a PHP syntax error.
# Detailed explanation

Consider the following Jade template:

```
-$a = range(1, rand(1, 10))
ul
    -foreach $a as $n:
        li= $n
```

Previously this was compiled to the following PHP code which has a syntax error in line 3:

```
<?php $a = range(1, rand(1, 10)) ?>
<ul>
  <?php for(each $a as $n) { ?>
    <li>
      <?php echo htmlspecialchars($n) ?>
    </li>
  <?php } ?>
</ul>
```

With simply putting the `foreach` keyword before `for` we get the correct PHP code:

```
<?php $a = range(1, rand(1, 10)) ?>
<ul>
  <?php foreach($a as $n) { ?>
    <li>
      <?php echo htmlspecialchars($n) ?>
    </li>
  <?php } ?>
</ul>
```
